### PR TITLE
グループ（JP, EN, ID）によるソート機能実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@ Homestead.json
 Homestead.yaml
 npm-debug.log
 yarn-error.log
-table.md
 /sql
 /public/css
 /public/js

--- a/app/Http/Controllers/API/GroupController.php
+++ b/app/Http/Controllers/API/GroupController.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Group;
+
+class GroupController extends Controller
+{
+    public function __construct(Group $group)
+    {
+        $this->group = $group;
+    }
+
+    public function index()
+    {
+        return $this->group->getAllGroups();
+    }
+}

--- a/app/Http/Controllers/API/YoutubeController.php
+++ b/app/Http/Controllers/API/YoutubeController.php
@@ -24,13 +24,41 @@ class YoutubeController extends Controller
     /**
      * 配信情報一覧取得
      *
-     * @return Array
+     * @return object Collection
      */
-    public function index()
+    public function index(): object
     {
-        $videos = $this->dailyUpcomingVideos->getVideos();
+        return $this->dailyUpcomingVideos->getVideos();
+    }
 
-        return $videos;
+    /**
+     * 日本グループの配信情報を取得
+     *
+     * @return object Collection
+     */
+    public function jp(): object
+    {
+        return $this->dailyUpcomingVideos->getJpVideos();
+    }
+
+    /**
+     * 英語グループの配信情報を取得
+     *
+     * @return object Collection
+     */
+    public function en(): object
+    {
+        return $this->dailyUpcomingVideos->getEnVideos();
+    }
+
+    /**
+     * インドネシアグループの配信情報を取得
+     *
+     * @return object Collection
+     */
+    public function id(): object
+    {
+        return $this->dailyUpcomingVideos->getIdVideos();
     }
 
     /**

--- a/app/Models/DailyUpcomingVideos.php
+++ b/app/Models/DailyUpcomingVideos.php
@@ -9,7 +9,6 @@ use Illuminate\Database\Eloquent\Model;
 
 class DailyUpcomingVideos extends Model
 {
-    protected $table = 'daily_upcoming_videos';
     protected $appends = [
         'start_date',
         'start_time',
@@ -28,11 +27,41 @@ class DailyUpcomingVideos extends Model
     /**
      * 登録されている配信予定動画を全て取得
      *
-     * @return object DailyUpcomingVideos
+     * @return object Collection
      */
     public function getVideos(): object
     {
         return $this->with('member')->orderBy('scheduled_start_time', 'asc')->get();
+    }
+
+    /**
+     * 日本グループの配信動画を取得
+     *
+     * @return object Collection
+     */
+    public function getJpVideos(): object
+    {
+        return $this->with('member')->where('country', 'JP')->orderBy('scheduled_start_time', 'asc')->get();
+    }
+
+    /**
+     * 英語グループの配信動画を取得
+     *
+     * @return object Collection
+     */
+    public function getEnVideos(): object
+    {
+        return $this->with('member')->where('country', 'EN')->orderBy('scheduled_start_time', 'asc')->get();
+    }
+
+    /**
+     * インドネシアグループの配信動画を取得
+     *
+     * @return object Collection
+     */
+    public function getIdVideos(): object
+    {
+        return $this->with('member')->where('country', 'ID')->orderBy('scheduled_start_time', 'asc')->get();
     }
 
     /**

--- a/app/Models/Group.php
+++ b/app/Models/Group.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Group extends Model
+{
+    protected $table = 'HOLOLIVE_GROUP_MST';
+
+    public function getAllGroups()
+    {
+        return $this->all();
+    }
+}

--- a/app/Models/Member.php
+++ b/app/Models/Member.php
@@ -21,6 +21,6 @@ class Member extends Model
      */
     public function getAllMembers(): object
     {
-        return $this::all();
+        return $this->all();
     }
 }

--- a/app/Repositories/Guzzle/GuzzleRepository.php
+++ b/app/Repositories/Guzzle/GuzzleRepository.php
@@ -28,6 +28,11 @@ class GuzzleRepository implements GuzzleRepositoryInterface
         try {
             return $this->client->request(GuzzleRepositoryConsts::GET_METHOD, $url);
         } catch (Exception $e) {
+            if (!config('app.SUB_API_KEY')) {
+                Log::debug("エラー内容:" . $e->getMessage() . PHP_EOL . "ファイル名:" . $e->getFile() . PHP_EOL . "エラー行:" . $e->getLine());
+                throw new RedirectExceptions(route('root'), "1日のクォータ使用量を超えているため、リクエストを完了できません。", $e->getCode());
+            }
+
             return $e;
         }
     }

--- a/database/migrations/2022_03_19_113321_create_hololive_group_mst.php
+++ b/database/migrations/2022_03_19_113321_create_hololive_group_mst.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateHololiveGroupMst extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('HOLOLIVE_GROUP_MST', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('name', 2)->unique();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('HOLOLIVE_GROUP_MST');
+    }
+}

--- a/readme.md
+++ b/readme.md
@@ -15,6 +15,48 @@
 そのため配信情報を可視化できるようなアプリを開発したいと考えた。<br>
 ホロライブを運営しているカバー株式会社が「ホロジュール」というメンバーのスケジュール管理アプリを既にリリースしているのだが、そこと差別化を図れるような取り組みを今後行っていく。(2022年2月21日現在)<br>
 
+## 事前準備
+- Google Cloud PlatformでYoutube Data APIを有効化したプロジェクトが作成済みであること（2つあると良し）
+
+## 環境構築
+1. envファイルを作成
+```shell
+copy .env.example .env
+```
+
+2. envファイル内で環境変数の値を設定
+```shell
+WEB_PORT=
+DB_PORT=
+
+DB_NAME=
+DB_USER=
+DB_PASSWORD=
+DB_ROOT_PASSWORD=
+
+API_KEY=
+# 2つプロジェクトを作成している場合
+SUB_API_KEY=
+```
+
+3. build
+```shell
+docker compose build
+
+docker compose up -d
+```
+
+4. composer インストール確認
+```shell
+composer -V
+Composer version 2.0.14 2021-05-21 17:03:37
+```
+
+5. Vue.js Install
+```
+npm install -D vue
+```
+
 ## 開発言語
 ### フロントエンド
 | 言語         | バージョン |
@@ -43,6 +85,7 @@
 | npm         | 8.1.2 |
 | webpack     | 5.9.0 |
 | laravel-mix | 6.0.18 |
+| vue-router | 4.0.12 |
 
 ## 機能一覧
 - 配信情報一覧

--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@
 ホロライブを運営しているカバー株式会社が「ホロジュール」というメンバーのスケジュール管理アプリを既にリリースしているのだが、そこと差別化を図れるような取り組みを今後行っていく。(2022年2月21日現在)<br>
 
 ## 事前準備
-- Google Cloud PlatformでYoutube Data APIを有効化したプロジェクトが作成済みであること（2つあると良し）
+- Google Cloud PlatformでYoutube Data APIを有効化したAPIキーが作成済みであること（1つでも可能だが、クォータ制限にすぐ引っかかってしまうため2つあると良い）
 
 ## 環境構築
 1. envファイルを作成
@@ -90,6 +90,7 @@ npm install -D vue
 ## 機能一覧
 - 配信情報一覧
 - YouTube Data APIを叩いた配信情報取得
+- ソート機能（JP, EN, ID）
 
 ## ER図
 ![HoloMemory](https://user-images.githubusercontent.com/56289802/154892094-dfcef436-0dac-4816-b433-436b92c047f3.jpg)

--- a/resources/js/components/ContainerComponent.vue
+++ b/resources/js/components/ContainerComponent.vue
@@ -125,6 +125,25 @@ export default {
             selectedGroup: "ALL",
         };
     },
+    computed: {
+        checkGroup: function () {
+            if (this.selectedGroup === "ALL") {
+                this.getVideos();
+                return true;
+            } else if (this.selectedGroup === "JP") {
+                this.getJpVideos();
+                return true;
+            } else if (this.selectedGroup === "EN") {
+                this.getEnVideos();
+                return true;
+            } else if (this.selectedGroup === "ID") {
+                this.getIdVideos();
+                return true;
+            }
+
+            return false;
+        },
+    },
     methods: {
         getGroups() {
             axios.get("api/groups").then((res) => {
@@ -134,6 +153,24 @@ export default {
         getVideos() {
             axios.get("api/videos").then((res) => {
                 console.log(res.data);
+                this.videos = res.data;
+                this.lessons = res.data;
+            });
+        },
+        getJpVideos() {
+            axios.get("api/videos/jp").then((res) => {
+                this.videos = res.data;
+                this.lessons = res.data;
+            });
+        },
+        getEnVideos() {
+            axios.get("api/videos/en").then((res) => {
+                this.videos = res.data;
+                this.lessons = res.data;
+            });
+        },
+        getIdVideos() {
+            axios.get("api/videos/id").then((res) => {
                 this.videos = res.data;
                 this.lessons = res.data;
             });

--- a/resources/js/components/ContainerComponent.vue
+++ b/resources/js/components/ContainerComponent.vue
@@ -28,6 +28,9 @@
         </div>
         <main>
             <div class="container">
+                <div v-if="checkEmptyVideos" class="text-center font-bold mt-5">
+                    {{ empty_message }}
+                </div>
                 <div v-if="checkGroup">
                     <div v-for="(video, index) in videos" :key="index">
                         <div
@@ -123,6 +126,7 @@ export default {
                 statusCode: this.errors.statusCode,
             },
             selectedGroup: "ALL",
+            empty_message: "直近の配信予定はございません。",
         };
     },
     computed: {
@@ -142,6 +146,9 @@ export default {
             }
 
             return false;
+        },
+        checkEmptyVideos: function () {
+            return !this.videos.length;
         },
     },
     methods: {

--- a/resources/js/components/ContainerComponent.vue
+++ b/resources/js/components/ContainerComponent.vue
@@ -14,9 +14,21 @@
                 </form>
             </div>
         </div>
+        <div>
+            <select class="select-group" v-model="selectedGroup">
+                <option value="ALL">全て</option>
+                <option
+                    v-for="group in groups"
+                    :key="group"
+                    v-bind:value="group.name"
+                >
+                    {{ group.name }}
+                </option>
+            </select>
+        </div>
         <main>
             <div class="container">
-                <div>
+                <div v-if="checkGroup">
                     <div v-for="(video, index) in videos" :key="index">
                         <div
                             class="date-section"
@@ -103,15 +115,22 @@ export default {
     props: ["errors"],
     data: function () {
         return {
+            groups: [],
             videos: [],
             lessons: [],
             error: {
                 exception: this.errors.exception,
                 statusCode: this.errors.statusCode,
             },
+            selectedGroup: "ALL",
         };
     },
     methods: {
+        getGroups() {
+            axios.get("api/groups").then((res) => {
+                this.groups = res.data;
+            });
+        },
         getVideos() {
             axios.get("api/videos").then((res) => {
                 console.log(res.data);
@@ -125,7 +144,8 @@ export default {
             });
         },
     },
-    mounted() {
+    created() {
+        this.getGroups();
         this.getVideos();
     },
 };

--- a/resources/js/components/ContainerComponent.vue
+++ b/resources/js/components/ContainerComponent.vue
@@ -135,21 +135,22 @@ export default {
     },
     computed: {
         checkGroup: function () {
-            if (this.selectedGroup === "ALL") {
-                this.getVideos(this.all_url);
-                return true;
-            } else if (this.selectedGroup === "JP") {
-                this.getVideos(this.jp_url);
-                return true;
-            } else if (this.selectedGroup === "EN") {
-                this.getVideos(this.en_url);
-                return true;
-            } else if (this.selectedGroup === "ID") {
-                this.getVideos(this.id_url);
-                return true;
+            switch (this.selectedGroup) {
+                case "ALL":
+                    this.getVideos(this.all_url);
+                    return true;
+                case "JP":
+                    this.getVideos(this.jp_url);
+                    return true;
+                case "EN":
+                    this.getVideos(this.en_url);
+                    return true;
+                case "ID":
+                    this.getVideos(this.id_url);
+                    return true;
+                default:
+                    return false;
             }
-
-            return false;
         },
         checkEmptyVideos: function () {
             return !this.videos.length;
@@ -170,7 +171,7 @@ export default {
         },
         submit() {
             axios.get("/api/videos/create").then(() => {
-                this.getVideos();
+                this.checkGroup();
             });
         },
     },

--- a/resources/js/components/ContainerComponent.vue
+++ b/resources/js/components/ContainerComponent.vue
@@ -126,22 +126,26 @@ export default {
                 statusCode: this.errors.statusCode,
             },
             selectedGroup: "ALL",
+            all_url: "api/videos",
+            jp_url: "api/videos/jp",
+            en_url: "api/videos/en",
+            id_url: "api/videos/id",
             empty_message: "直近の配信予定はございません。",
         };
     },
     computed: {
         checkGroup: function () {
             if (this.selectedGroup === "ALL") {
-                this.getVideos();
+                this.getVideos(this.all_url);
                 return true;
             } else if (this.selectedGroup === "JP") {
-                this.getJpVideos();
+                this.getVideos(this.jp_url);
                 return true;
             } else if (this.selectedGroup === "EN") {
-                this.getEnVideos();
+                this.getVideos(this.en_url);
                 return true;
             } else if (this.selectedGroup === "ID") {
-                this.getIdVideos();
+                this.getVideos(this.id_url);
                 return true;
             }
 
@@ -157,27 +161,9 @@ export default {
                 this.groups = res.data;
             });
         },
-        getVideos() {
-            axios.get("api/videos").then((res) => {
+        getVideos(url) {
+            axios.get(url).then((res) => {
                 console.log(res.data);
-                this.videos = res.data;
-                this.lessons = res.data;
-            });
-        },
-        getJpVideos() {
-            axios.get("api/videos/jp").then((res) => {
-                this.videos = res.data;
-                this.lessons = res.data;
-            });
-        },
-        getEnVideos() {
-            axios.get("api/videos/en").then((res) => {
-                this.videos = res.data;
-                this.lessons = res.data;
-            });
-        },
-        getIdVideos() {
-            axios.get("api/videos/id").then((res) => {
                 this.videos = res.data;
                 this.lessons = res.data;
             });
@@ -190,7 +176,7 @@ export default {
     },
     created() {
         this.getGroups();
-        this.getVideos();
+        this.getVideos(this.all_url);
     },
 };
 </script>

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -19,6 +19,9 @@
     .request-button {
         @apply bg-gray-700 hover:bg-gray-900 text-white font-bold py-2 px-4 border border-gray-900 rounded;
     }
+    .select-group {
+        @apply w-auto px-3 py-1.5 text-base font-normal text-gray-700 border border-solid border-gray-600 rounded transition ease-in-out focus:text-gray-700 focus:bg-white focus:border-blue-600 focus:outline-none;
+    }
     .lessons {
         @apply flex flex-wrap items-center justify-start;
     }

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,5 +1,12 @@
 <?php
 Route::middleware(['middleware' => 'api'])->group(function () {
-    Route::get('/videos', 'Api\YoutubeController@index')->name('videos.index');
-    Route::get('/videos/create', 'Api\YoutubeController@store')->name('videos.create');
+    Route::group(['as' => 'videos.'], function () {
+        Route::get('/videos', 'Api\YoutubeController@index')->name('index');
+        Route::get('/videos/jp', 'Api\YoutubeController@jp')->name('jp');
+        Route::get('/videos/en', 'Api\YoutubeController@en')->name('en');
+        Route::get('/videos/id', 'Api\YoutubeController@id')->name('id');
+        Route::get('/videos/create', 'Api\YoutubeController@store')->name('create');
+    });
+
+    Route::get('/groups', 'Api\GroupController@index')->name('groups.index');
 });

--- a/table.md
+++ b/table.md
@@ -1,0 +1,42 @@
+# テーブル定義書
+
+| テーブル論理名   | テーブル物理名      |
+| ---------------- | ------------------- |
+| メンバーマスター | HOLOLIVE_MEMBER_MST |
+
+| NO. | PK  | UK  | カラム論理名           | カラム物理名     | データ型     | 桁  | NULL | DEFAULT | 備考                                      |
+| --- | --- | --- | ---------------------- | ---------------- | ------------ | --- | ---- | ------- | ----------------------------------------- |
+| 1   | ◯   | N/A | メンバー ID            | id               | INT unsigned | N/A | NO   | N/A     | auto_increment                            |
+| 2   | N/A | N/A | 名前                   | name             | STRING       | 30  | NO   | N/A     |                                           |
+| 3   | N/A | ◯   | チャンネル ID          | channel_id       | STRING       | 255 | NO   | N/A     | 各チャンネルページの channel/以降の文字列 |
+| 4   | N/A | N/A | 期生 ID                | graduate_id      | INT unsigned | N/A | NO   | N/A     | ゲーマーズ:99、IRys:98                    |
+| 5   | N/A | N/A | チャンネルアイコン URL | channel_icon_url | STRING       | 255 | NO   | N/A     |                                           |
+| 6   | N/A | N/A | 出身国                 | country          | STRING       | 10  | NO   | N/A     | JP(日本)/EN(英語圏)/ID（インドネシア）    |
+| 7   | N/A | N/A | 作成日時               | created_at       | TIMESTAMP    | N/A | YES  | N/A     |                                           |
+| 8   | N/A | N/A | 更新日時               | updated_at       | TIMESTAMP    | N/A | YES  | N/A     |                                           |
+
+| テーブル論理名   | テーブル物理名     |
+| ---------------- | ------------------ |
+| グループマスター | HOLOLIVE_GROUP_MST |
+
+| NO. | PK  | UK  | カラム論理名 | カラム物理名 | データ型  | 桁  | NULL | DEFAULT | 備考 |
+| --- | --- | --- | ------------ | ------------ | --------- | --- | ---- | ------- | ---- |
+| 1   | ◯   | N/A | グループ ID  | id           | INT       | N/A | NO   | N/A     |      |
+| 2   | N/A | ◯   | グループ名   | name         | STRING    | 10  | NO   | N/A     |      |
+| 3   | N/A | N/A | 作成日時     | created_at   | TIMESTAMP | N/A | YES  | N/A     |      |
+| 4   | N/A | N/A | 更新日時     | updated_at   | TIMESTAMP | N/A | YES  | N/A     |      |
+
+| テーブル論理名 | テーブル物理名        |
+| -------------- | --------------------- |
+| 配信予定動画   | daily_upcoming_videos |
+
+| NO. | PK  | UK  | カラム論理名   | カラム物理名         | データ型  | 桁  | NULL | DEFAULT | 備考                                      |
+| --- | --- | --- | -------------- | -------------------- | --------- | --- | ---- | ------- | ----------------------------------------- |
+| 1   | N/A | MUL | チャンネル ID  | channel_id           | STRING    | 255 | NO   | N/A     | 各チャンネルページの channel/以降の文字列 |
+| 2   | N/A | N/A | 出身国         | country              | STRING    | 2   | NO   | N/A     | JP(日本)/EN(英語圏)/ID（インドネシア）    |
+| 3   | N/A | N/A | 動画 ID        | video_id             | STRING    | 255 | NO   | N/A     |                                           |
+| 4   | N/A | N/A | タイトル       | title                | STRING    | 255 | NO   | N/A     |                                           |
+| 5   | N/A | N/A | サムネイル URL | thumbnails_url       | STRING    | 255 | NO   | N/A     |                                           |
+| 6   | N/A | N/A | 配信開始時間   | scheduled_start_time | STRING    | 255 | NO   | N/A     |                                           |
+| 7   | N/A | N/A | 作成日時       | created_at           | TIMESTAMP | N/A | YES  | N/A     |                                           |
+| 8   | N/A | N/A | 更新日時       | updated_at           | TIMESTAMP | N/A | YES  | N/A     |                                           |


### PR DESCRIPTION
### 実装内容
- グループを選択するセレクトボックスを設置
- グループ（JP, EN, ID）ごとに配信情報を取得するソート機能を実装
- 配信情報が空だった際にメッセージを表示

### 懸念点
- 配信情報が空でなくても、空のメッセージがはじめに表示されてしまう（空判定の処理が先に走ってしまうため）
- 各グループの配信情報をAPI経由でそれぞれ取得しているため、工程が一つ多くなってしまう。
  できればJSだけで判定できるようにしたい