### PR TITLE
最新配信情報取得時に、現在のセレクトボックスで選択されているグループの動画が表示されるように実装

### DIFF
--- a/resources/js/components/ContainerComponent.vue
+++ b/resources/js/components/ContainerComponent.vue
@@ -131,6 +131,7 @@ export default {
             en_url: "api/videos/en",
             id_url: "api/videos/id",
             empty_message: "直近の配信予定はございません。",
+            undefind_group_message: "存在しないグループです。",
         };
     },
     computed: {
@@ -162,6 +163,24 @@ export default {
                 this.groups = res.data;
             });
         },
+        getGroupVideos() {
+            switch (this.selectedGroup) {
+                case "ALL":
+                    this.getVideos(this.all_url);
+                    break;
+                case "JP":
+                    this.getVideos(this.jp_url);
+                    break;
+                case "EN":
+                    this.getVideos(this.en_url);
+                    break;
+                case "ID":
+                    this.getVideos(this.id_url);
+                    break;
+                default:
+                    return this.undefind_group_message;
+            }
+        },
         getVideos(url) {
             axios.get(url).then((res) => {
                 console.log(res.data);
@@ -171,7 +190,7 @@ export default {
         },
         submit() {
             axios.get("/api/videos/create").then(() => {
-                this.checkGroup();
+                this.getGroupVideos();
             });
         },
     },


### PR DESCRIPTION
### 実装内容
- 最新配信情報取得時に、現在のセレクトボックスで選択されているグループの動画が表示されるように実装

### 改善していきたい点
- 同じようなswitch文を量産してしまっている
- Vueの基本構文からベストプラクティス、正い使い方等を基礎をしっかり学び直した上で改修する必要がある